### PR TITLE
fix: set repository URL

### DIFF
--- a/packages/cap-router/package.json
+++ b/packages/cap-router/package.json
@@ -17,5 +17,10 @@
   "type": "module",
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.58.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/cap-router"
   }
 }

--- a/packages/hashline-edit/package.json
+++ b/packages/hashline-edit/package.json
@@ -32,5 +32,10 @@
     "@mariozechner/pi-ai": "*",
     "@sinclair/typebox": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/hashline-edit"
+  }
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -36,5 +36,10 @@
   "devDependencies": {
     "@mariozechner/pi-coding-agent": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/observability"
+  }
 }

--- a/packages/return-type/package.json
+++ b/packages/return-type/package.json
@@ -31,5 +31,10 @@
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/return-type"
+  }
 }

--- a/packages/spec-kit/package.json
+++ b/packages/spec-kit/package.json
@@ -29,5 +29,10 @@
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/spec-kit"
   }
 }

--- a/packages/task-tree/package.json
+++ b/packages/task-tree/package.json
@@ -39,5 +39,10 @@
   },
   "dependencies": {
     "yaml": "^2.8.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/task-tree"
   }
 }

--- a/packages/tokenshrink/package.json
+++ b/packages/tokenshrink/package.json
@@ -34,5 +34,10 @@
   "dependencies": {
     "tokenshrink": "^2.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/tokenshrink"
+  }
 }

--- a/packages/vmpi/package.json
+++ b/packages/vmpi/package.json
@@ -41,5 +41,10 @@
     "@types/node-forge": "^1.3.14",
     "tsx": "^4.21.0",
     "typescript": "^5.5.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JoshMock/the-agency.git",
+    "directory": "packages/vmpi"
   }
 }


### PR DESCRIPTION
required for npm trusted publishing
