### PR TITLE
feat: post-setup hooks

### DIFF
--- a/packages/vmpi/README.md
+++ b/packages/vmpi/README.md
@@ -119,6 +119,7 @@ To use the `gh` CLI inside the sandbox, add the `github` network preset and forw
     "providers": ["anthropic", "github"]
   },
   "guestPackages": ["github-cli"],
+  "postSetupHooks": ["npm install -g typescript"],
   "secrets": {
     "GITHUB_TOKEN": { "hosts": ["api.github.com", "github.com"] }
   }
@@ -139,6 +140,7 @@ To use the `gh` CLI inside the sandbox, add the `github` network preset and forw
 | `network.localServices` | `[]` | Host services to expose inside the VM. Each entry is `{ hostname, port }`. The VM can reach `hostname` at the given host `port` via a raw TCP tunnel. |
 | `rootfsExtraMb` | `128` | MiB to add to the Gondolin rootfs image during `vmpi setup` when free space is below this threshold. Increase this if setup fails with a disk-full error. |
 | `guestPackages` | `[]` | Extra Alpine packages to install in the guest during `vmpi setup`, in addition to the defaults: `git`, `fd`, `ripgrep`, `curl`, `jq`, `bash`, `python3`, `py3-pip`, `nodejs`, `npm`, `make`, `patch`, `file`, `sqlite`. |
+| `postSetupHooks` | `[]` | Shell commands to run inside the VM after packages are installed, before the checkpoint is saved. Each command runs via `/bin/sh -c`. A non-zero exit aborts setup. Use this to install tools not available as Alpine packages, e.g. `npm install -g typescript` or `gem install rails`. |
 | `secrets` | `{}` | Secrets to inject into the VM, each scoped to specific hosts using [Gondolin's secret handling](https://earendil-works.github.io/gondolin/secrets/). Each key is the guest env var name. Value: `{ "hosts": ["api.github.com"] }`. Override the host-side var name with `"env"`: `{ "hosts": [...], "env": "MY_PAT" }`. Values are passed via a tmpfs env file and never written to persistent storage. |
 Environment variables (`VMPI_MEMORY`, `VMPI_CPUS`, `PI_CONFIG_DIR`, `VMPI_STATE_DIR`, `VMPI_ROOTFS_EXTRA_MB`) override their config file equivalents.
 

--- a/packages/vmpi/config.test.ts
+++ b/packages/vmpi/config.test.ts
@@ -268,6 +268,17 @@ describe('loadConfig', () => {
     }
   })
 
+  it('returns empty postSetupHooks when not configured', () => {
+    const cfg = loadConfig()
+    assert.deepEqual(cfg.postSetupHooks, [])
+  })
+
+  it('passes postSetupHooks from config file through unchanged', () => {
+    writeFileSync(join(tmpDir, '.vmpirc.json'), JSON.stringify({ postSetupHooks: ['npm install -g typescript', 'gem install rails'] }))
+    const cfg = loadConfig()
+    assert.deepEqual(cfg.postSetupHooks, ['npm install -g typescript', 'gem install rails'])
+  })
+
   it('finds config file in a parent directory', () => {
     const subDir = join(tmpDir, 'nested', 'child')
     mkdirSync(subDir, { recursive: true })

--- a/packages/vmpi/config.ts
+++ b/packages/vmpi/config.ts
@@ -178,6 +178,15 @@ export interface VmpiConfig {
   guestPackages?: string[]
 
   /**
+   * Shell commands to run inside the VM after packages are installed, before
+   * the base checkpoint is saved. Each command is executed via `/bin/sh -c`.
+   * A non-zero exit code aborts setup. Useful for installing language-specific
+   * tools that are not available as Alpine packages, e.g.:
+   * `["npm install -g typescript", "gem install rails"]`.
+   */
+  postSetupHooks?: string[]
+
+  /**
    * Secrets to inject into the VM at runtime.
    * Each key is the env var name set inside the VM; the value object specifies
    * the allowed hosts and the host-side env var to read from.
@@ -209,6 +218,8 @@ export interface ResolvedConfig {
   rootfsExtraMb: number
   /** Alpine packages to install in the guest (defaults + user extras). */
   guestPackages: string[]
+  /** Shell commands to run after package installation, before checkpointing. */
+  postSetupHooks: string[]
   network: ResolvedNetwork
   /**
    * Resolved secrets ready to pass to Gondolin's `createHttpHooks`.
@@ -387,6 +398,7 @@ export function loadConfig(): ResolvedConfig {
   const policy = resolvePolicy(file.network, allowedDomains)
   const localServices = resolveLocalServices(file.network)
   const guestPackages = resolveGuestPackages(file.guestPackages)
+  const postSetupHooks = file.postSetupHooks ?? []
   const { resolved: secrets, missing: missingSecrets } = resolveSecrets(file.secrets)
 
   if (policy === 'deny-all' && allowedDomains.length > 0) {
@@ -396,7 +408,7 @@ export function loadConfig(): ResolvedConfig {
     )
   }
 
-  return { memory, cpus, piConfigDir, stateDir, rootfsExtraMb, guestPackages, secrets, missingSecrets, network: { policy, allowedDomains, localServices } }
+  return { memory, cpus, piConfigDir, stateDir, rootfsExtraMb, guestPackages, postSetupHooks, secrets, missingSecrets, network: { policy, allowedDomains, localServices } }
 }
 
 /** Parses a string as a number, returning undefined for missing/NaN values. */

--- a/packages/vmpi/vmpi.ts
+++ b/packages/vmpi/vmpi.ts
@@ -182,7 +182,7 @@ function debugLog(): VMOptions['debugLog'] {
  * In debug mode both streams are shown, prefixed with [stdout]/[stderr].
  * Throws if the command exits with a non-zero code.
  */
-async function vmExec(vm: VM, cmd: string): Promise<void> {
+async function vmExec(vm: VM, cmd: string, { forwardStdout = true }: { forwardStdout?: boolean } = {}): Promise<void> {
   // Use array form (/bin/sh -c) rather than string form (/bin/sh -lc) because
   // the Alpine login shell doesn't populate PATH, so `npm`, `pi`, etc. are not
   // found when using the login-shell string shorthand.
@@ -192,6 +192,8 @@ async function vmExec(vm: VM, cmd: string): Promise<void> {
       process.stderr.write(`[${stream}] ${text}`)
     } else if (stream === 'stderr') {
       process.stderr.write(text)
+    } else if (stream === 'stdout' && forwardStdout) {
+      process.stdout.write(text)
     }
   }
   const result = await proc
@@ -376,15 +378,20 @@ async function cmdSetup(): Promise<void> {
   mkdirSync(getConfig().stateDir, { recursive: true })
 
   const piBundle = await buildPiBundle()
-  const { memory, cpus, guestPackages } = getConfig()
+  const { memory, cpus, guestPackages, postSetupHooks } = getConfig()
 
   // `cow` rootfs mode requires `qemu-img`; `memory` uses QEMU's built-in
   // snapshot mode and needs no extra tooling. We use `cow` here because we
   // are about to checkpoint the disk.
+  // Allow-all HTTP hooks so post-setup hooks (e.g. `npm install -g …`) can
+  // reach the internet. Setup runs under host control, not sandboxed pi, so
+  // the user's runtime network policy does not apply here.
+  const { httpHooks: setupHttpHooks } = createHttpHooks({ allowedHosts: undefined } as any)
   const vm = await VM.create({
     sandbox: sandboxOptions(),
     memory: `${memory}M`,
     cpus,
+    httpHooks: setupHttpHooks,
     startTimeoutMs: 0,
     debugLog: debugLog(),
   })
@@ -408,6 +415,14 @@ async function cmdSetup(): Promise<void> {
 
     info(`Installing guest packages: ${guestPackages.join(', ')}...`)
     await vm.exec(['/bin/sh', '-c', `apk add --no-cache ${guestPackages.join(' ')}`])
+
+    if (postSetupHooks.length > 0) {
+      info(`Running ${postSetupHooks.length} post-setup hook(s)...`)
+      for (const cmd of postSetupHooks) {
+        info(`  $ ${cmd}`)
+        await vmExec(vm, cmd)
+      }
+    }
 
     info('Creating base checkpoint...')
     const checkpoint = await vm.checkpoint(checkpointFile())
@@ -537,7 +552,7 @@ async function cmdRun(args: string[]): Promise<void> {
       'tar xzf /opt/pi-modules.tgz -C /tmp/lib/',
       'npm config set prefix /tmp',
       'ln -sf /tmp/lib/node_modules/.bin/pi /usr/bin/pi',
-    ].join(' && '))
+    ].join(' && '), { forwardStdout: false })
 
     if (debugMode) {
       debugDeniedHosts = new Set()


### PR DESCRIPTION
Add the ability to run arbitrary commands during `vmpi setup`.
